### PR TITLE
Fix: JSON deserialization

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -54,6 +54,14 @@ where
                 })
             }
 
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error, {
+                v.parse().map_err(|_| {
+                    serde::de::Error::custom(format!("failed to parse string as number"))
+                })
+            }
+
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
             where
                 E: serde::de::Error,


### PR DESCRIPTION
I tried to deserialize a JSON struct of type `MinaBaseProofStableV2` and got an error that serde was expecting a "stringified number". The JSON had indeed a stringified number in place, but it couldn't deserialize it.

I looked into it and saw a clippy error: https://rust-lang.github.io/rust-clippy/master/index.html#serde_api_misuse

It seems that each time the method visit_string is implemented, we also need to implement visit_str and vice versa. After this fix, serde could deserialize the type just fine :) 

@akoptelov This is a small fix but just in case I put it in a PR to keep things clean, please merge when you see fit :) 