### PR TITLE
Add `derive_more::Deref` to generated types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ mina-signer = {git = "https://github.com/o1-labs/proof-systems", rev = "bb0bb776
 o1-utils = {git = "https://github.com/o1-labs/proof-systems", rev = "bb0bb776ba6ef39750ac92557947a81c2144b63a", optional = true }
 base64 = "0.13.1"
 
+ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ], optional = true }
+
 [target.'cfg(fuzzing)'.dev-dependencies]
 fuzzcheck = "0.12.1"
 
@@ -36,7 +38,7 @@ time = { version = "0.3.17", features = ["formatting"] }
 
 
 [features]
-hashing = ["mina-hasher", "mina-curves", "mina-signer", "o1-utils", "sha2"]
+hashing = ["mina-hasher", "mina-curves", "mina-signer", "o1-utils", "sha2", "ark-ff"]
 
 [target.wasm32-unknown-unknown.dev-dependencies]
 web-sys = { version = "0.3.60", features = ["console"] }

--- a/src/b58.rs
+++ b/src/b58.rs
@@ -100,6 +100,14 @@ impl<T, U, const V: u8> From<T> for Base58CheckOfBinProt<T, U, V> {
     }
 }
 
+impl<T, U, const V: u8> std::ops::Deref for Base58CheckOfBinProt<T, U, V> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl<T, U, const V: u8> Base58CheckOfBinProt<T, U, V> {
     pub fn into_inner(self) -> T {
         self.0

--- a/src/b58.rs
+++ b/src/b58.rs
@@ -194,6 +194,14 @@ impl<T, const V: u8> Base58CheckOfBytes<T, V> {
     }
 }
 
+impl<T, const V: u8> std::ops::Deref for Base58CheckOfBytes<T, V> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl<T, const V: u8> Serialize for Base58CheckOfBytes<T, V>
 where
     T: Serialize + AsRef<[u8]> + std::fmt::Debug,

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -13,7 +13,7 @@ impl BigInt {
     #[cfg(feature = "hashing")]
     pub fn to_field<F>(&self) -> F
     where
-        F: ark_ff::Field
+        F: ark_ff::Field,
     {
         let mut slice: &[u8] = self.0.as_ref();
         F::read(&mut slice).expect("Conversion BigInt to Field failed")

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -10,6 +10,15 @@ impl BigInt {
         mina_hasher::Fp::from_bytes(self.0.as_ref())
     }
 
+    #[cfg(feature = "hashing")]
+    pub fn to_field<F>(&self) -> F
+    where
+        F: ark_ff::Field
+    {
+        let mut slice: &[u8] = self.0.as_ref();
+        F::read(&mut slice).expect("Conversion BigInt to Field failed")
+    }
+
     pub fn iter_bytes<'a>(&'a self) -> impl 'a + DoubleEndedIterator<Item = u8> {
         self.0.iter().cloned()
     }

--- a/src/char.rs
+++ b/src/char.rs
@@ -4,6 +4,20 @@ use serde::{de::Visitor, Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Char(pub u8);
 
+impl std::ops::Deref for Char {
+    type Target = u8;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Char {
+    pub fn as_u8(&self) -> u8 {
+        self.0
+    }
+}
+
 impl Serialize for Char {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/char.rs
+++ b/src/char.rs
@@ -2,7 +2,7 @@ use binprot::byteorder::{ReadBytesExt, WriteBytesExt};
 use serde::{de::Visitor, Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Char(u8);
+pub struct Char(pub u8);
 
 impl Serialize for Char {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/number.rs
+++ b/src/number.rs
@@ -18,11 +18,15 @@ impl<T> std::ops::Deref for Number<T> {
 }
 
 impl Int32 {
-    pub fn as_u32(&self) -> u32 { self.0 as u32 }
+    pub fn as_u32(&self) -> u32 {
+        self.0 as u32
+    }
 }
 
 impl Int64 {
-    pub fn as_u64(&self) -> u64 { self.0 as u64 }
+    pub fn as_u64(&self) -> u64 {
+        self.0 as u64
+    }
 }
 
 impl<T> Serialize for Number<T>

--- a/src/number.rs
+++ b/src/number.rs
@@ -9,6 +9,22 @@ pub type Int32 = Number<i32>;
 pub type Int64 = Number<i64>;
 pub type Float64 = Number<f64>;
 
+impl<T> std::ops::Deref for Number<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Int32 {
+    pub fn as_u32(&self) -> u32 { self.0 as u32 }
+}
+
+impl Int64 {
+    pub fn as_u64(&self) -> u64 { self.0 as u64 }
+}
+
 impl<T> Serialize for Number<T>
 where
     T: Serialize + Display,

--- a/src/pseq.rs
+++ b/src/pseq.rs
@@ -5,6 +5,14 @@ use serde::ser::SerializeTuple;
 #[derive(Clone, Debug, PartialEq)]
 pub struct PaddedSeq<T, const N: usize>(pub [T; N]);
 
+impl<T, const N: usize> std::ops::Deref for PaddedSeq<T, N> {
+    type Target = [T; N];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl<T: BinProtRead, const N: usize> binprot::BinProtRead for PaddedSeq<T, N> {
     fn binprot_read<R: std::io::Read + ?Sized>(r: &mut R) -> Result<Self, binprot::Error>
     where

--- a/src/string.rs
+++ b/src/string.rs
@@ -5,6 +5,14 @@ use serde::{de::Visitor, Deserialize, Serialize};
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ByteString(Vec<u8>);
 
+impl std::ops::Deref for ByteString {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl AsRef<[u8]> for ByteString {
     fn as_ref(&self) -> &[u8] {
         &self.0

--- a/src/v1/hashing.rs
+++ b/src/v1/hashing.rs
@@ -38,7 +38,7 @@ impl Hashable for generated::UnsignedExtendedUInt32StableV1VersionedV1 {
 
     fn to_roinput(&self) -> ROInput {
         // TODO: should be u32 not i32?
-        ROInput::new().append_u32(self.0.0 as u32)
+        ROInput::new().append_u32(self.0 .0 as u32)
     }
 
     fn domain_string(_: Self::D) -> Option<String> {
@@ -51,7 +51,7 @@ impl Hashable for generated::UnsignedExtendedUInt64StableV1VersionedV1 {
 
     fn to_roinput(&self) -> ROInput {
         // TODO: should be u64 not i64?
-        ROInput::new().append_u64(self.0.0 as u64)
+        ROInput::new().append_u64(self.0 .0 as u64)
     }
 
     fn domain_string(_: Self::D) -> Option<String> {
@@ -217,7 +217,7 @@ impl Hashable for generated::MinaBaseTokenIdStableV1VersionedV1 {
 
     fn to_roinput(&self) -> ROInput {
         // TODO: should be u64 not i64?
-        ROInput::new().append_u64(self.0.inner().0.inner().0.0 as u64)
+        ROInput::new().append_u64(self.0.inner().0.inner().0 .0 as u64)
     }
 
     fn domain_string(_: Self::D) -> Option<String> {

--- a/src/v2/generated.rs
+++ b/src/v2/generated.rs
@@ -1,5 +1,6 @@
 use binprot_derive::{BinProtRead, BinProtWrite};
 use serde::{Deserialize, Serialize};
+use derive_more::Deref;
 
 use crate::pseq::PaddedSeq;
 
@@ -29,7 +30,7 @@ pub struct MinaBlockBlockStableV2 {
 /// Gid: `50`
 /// Location: [src/list0.ml:6:0](https://github.com/Minaprotocol/mina/blob/32a9161/src/list0.ml#L6)
 /// Args: MinaBaseUserCommandStableV2
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct NetworkPoolTransactionPoolDiffVersionedStableV2(pub Vec<MinaBaseUserCommandStableV2>);
 
 /// **OCaml name**: `Network_pool__Snark_pool.Diff_versioned.Stable.V2`
@@ -253,7 +254,7 @@ pub struct BlockchainSnarkBlockchainStableV2 {
 ///
 /// Gid: `73`
 /// Location: [src/string.ml:14:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/string.ml#L14)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBaseSokMessageDigestStableV1(pub crate::string::ByteString);
 
 /// Derived name: `Pickles__Proof.Proofs_verified_2.Repr.Stable.V2#statement#fp`
@@ -416,7 +417,7 @@ pub struct PicklesProofProofsVerified2ReprStableV2Proof {
 ///
 /// Gid: `500`
 /// Location: [src/binable0.ml:120:10](https://github.com/Minaprotocol/mina/blob/32a9161/src/binable0.ml#L120)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct Blake2MakeStableV1(pub crate::string::ByteString);
 
 /// **OCaml name**: `Pickles_base__Proofs_verified.Stable.V1`
@@ -438,7 +439,7 @@ pub enum PicklesBaseProofsVerifiedStableV1 {
 ///
 /// Gid: `125`
 /// Location: [src/int64.ml:6:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/int64.ml#L6)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct LimbVectorConstantHex64StableV1(pub crate::number::Int64);
 
 /// **OCaml name**: `Composition_types__Branch_data.Make_str.Domain_log2.Stable.V1`
@@ -453,7 +454,7 @@ pub struct LimbVectorConstantHex64StableV1(pub crate::number::Int64);
 ///
 /// Gid: `89`
 /// Location: [src/char.ml:8:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/char.ml#L8)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct CompositionTypesBranchDataDomainLog2StableV1(pub crate::char::Char);
 
 /// **OCaml name**: `Composition_types__Branch_data.Make_str.Stable.V1`
@@ -481,7 +482,7 @@ pub struct PicklesReducedMessagesForNextProofOverSameFieldWrapChallengesVectorSt
 ///
 /// Gid: `523`
 /// Location: [src/lib/pickles/composition_types/digest.ml:13:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/pickles/composition_types/digest.ml#L13)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct CompositionTypesDigestConstantStableV1(
     pub PaddedSeq<LimbVectorConstantHex64StableV1, 4>,
 );
@@ -584,7 +585,7 @@ pub struct PicklesProofProofsVerified2ReprStableV2MessagesForNextStepProof {
 /// Gid: `484`
 /// Location: [src/lib/crypto/kimchi_backend/pasta/basic/kimchi_pasta_basic.ml:32:8](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/crypto/kimchi_backend/pasta/basic/kimchi_pasta_basic.ml#L32)
 /// Args: PicklesReducedMessagesForNextProofOverSameFieldWrapChallengesVectorStableV2A
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct PicklesReducedMessagesForNextProofOverSameFieldWrapChallengesVectorStableV2(
     pub PaddedSeq<PicklesReducedMessagesForNextProofOverSameFieldWrapChallengesVectorStableV2A, 15>,
 );
@@ -644,7 +645,7 @@ pub struct PicklesProofProofsVerifiedMaxStableV2 {
 ///
 /// Gid: `125`
 /// Location: [src/int64.ml:6:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/int64.ml#L6)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct UnsignedExtendedUInt64Int64ForVersionTagsStableV1(pub crate::number::Int64);
 
 /// **OCaml name**: `Unsigned_extended.UInt32.Stable.V1`
@@ -655,14 +656,14 @@ pub struct UnsignedExtendedUInt64Int64ForVersionTagsStableV1(pub crate::number::
 ///
 /// Gid: `119`
 /// Location: [src/int32.ml:6:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/int32.ml#L6)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct UnsignedExtendedUInt32StableV1(pub crate::number::Int32);
 
 /// **OCaml name**: `Mina_numbers__Nat.Make32.Stable.V1`
 ///
 /// Gid: `549`
 /// Location: [src/lib/mina_numbers/nat.ml:261:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/mina_numbers/nat.ml#L261)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaNumbersNatMake32StableV1(pub UnsignedExtendedUInt32StableV1);
 
 /// **OCaml name**: `Sgn.Stable.V1`
@@ -701,21 +702,21 @@ pub struct MinaBaseFeeExcessStableV1Fee {
 ///
 /// Gid: `579`
 /// Location: [src/lib/currency/currency.ml:901:8](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/currency/currency.ml#L901)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct CurrencyFeeStableV1(pub UnsignedExtendedUInt64Int64ForVersionTagsStableV1);
 
 /// **OCaml name**: `Currency.Make_str.Amount.Make_str.Stable.V1`
 ///
 /// Gid: `582`
 /// Location: [src/lib/currency/currency.ml:1037:10](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/currency/currency.ml#L1037)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct CurrencyAmountStableV1(pub UnsignedExtendedUInt64Int64ForVersionTagsStableV1);
 
 /// **OCaml name**: `Currency.Make_str.Balance.Stable.V1`
 ///
 /// Gid: `585`
 /// Location: [src/lib/currency/currency.ml:1079:8](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/currency/currency.ml#L1079)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct CurrencyBalanceStableV1(pub CurrencyAmountStableV1);
 
 /// **OCaml name**: `Non_zero_curve_point.Uncompressed.Stable.V1`
@@ -737,14 +738,14 @@ pub struct NonZeroCurvePointUncompressedStableV1 {
 ///
 /// Gid: `616`
 /// Location: [src/lib/data_hash_lib/state_hash.ml:44:4](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/data_hash_lib/state_hash.ml#L44)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct DataHashLibStateHashStableV1(pub crate::bigint::BigInt);
 
 /// **OCaml name**: `Block_time.Make_str.Time.Stable.V1`
 ///
 /// Gid: `625`
 /// Location: [src/lib/block_time/block_time.ml:22:8](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/block_time/block_time.ml#L22)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct BlockTimeTimeStableV1(pub UnsignedExtendedUInt64Int64ForVersionTagsStableV1);
 
 /// Derived name: `Mina_base__Sparse_ledger_base.Stable.V2#tree`
@@ -795,7 +796,7 @@ pub enum TransactionSnarkWorkTStableV2Proofs {
 ///
 /// Gid: `631`
 /// Location: [src/lib/mina_base/account_id.ml:64:8](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/mina_base/account_id.ml#L64)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBaseAccountIdDigestStableV1(pub crate::bigint::BigInt);
 
 /// **OCaml name**: `Mina_base__Account_id.Make_str.Stable.V2`
@@ -853,7 +854,7 @@ pub enum MinaBaseControlStableV2 {
 ///
 /// Gid: `654`
 /// Location: [src/lib/mina_base/token_id.ml:8:4](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/mina_base/token_id.ml#L8)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBaseTokenIdStableV2(pub MinaBaseAccountIdDigestStableV1);
 
 /// **OCaml name**: `Mina_base__Fee_excess.Stable.V1`
@@ -893,7 +894,7 @@ pub struct MinaBasePaymentPayloadStableV2 {
 ///
 /// Gid: `670`
 /// Location: [src/lib/mina_base/ledger_hash0.ml:17:4](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/mina_base/ledger_hash0.ml#L17)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBaseLedgerHash0StableV1(pub crate::bigint::BigInt);
 
 /// **OCaml name**: `Mina_base__Permissions.Auth_required.Stable.V2`
@@ -945,7 +946,7 @@ pub struct MinaBasePermissionsStableV2 {
 ///
 /// Gid: `83`
 /// Location: [src/string.ml:44:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/string.ml#L44)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBaseSignedCommandMemoStableV1(pub crate::string::CharString);
 
 /// **OCaml name**: `Mina_base__Stake_delegation.Stable.V1`
@@ -1024,7 +1025,7 @@ pub enum MinaBaseTransactionStatusFailureStableV2 {
 /// Gid: `50`
 /// Location: [src/list0.ml:6:0](https://github.com/Minaprotocol/mina/blob/32a9161/src/list0.ml#L6)
 /// Args: Vec < MinaBaseTransactionStatusFailureStableV2 >
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBaseTransactionStatusFailureCollectionStableV1(
     pub Vec<Vec<MinaBaseTransactionStatusFailureStableV2>>,
 );
@@ -1102,14 +1103,14 @@ pub struct MinaBaseSignedCommandStableV2 {
 ///
 /// Gid: `719`
 /// Location: [src/lib/mina_base/receipt.ml:31:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/mina_base/receipt.ml#L31)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBaseReceiptChainHashStableV1(pub crate::bigint::BigInt);
 
 /// **OCaml name**: `Mina_base__State_body_hash.Stable.V1`
 ///
 /// Gid: `724`
 /// Location: [src/lib/mina_base/state_body_hash.ml:19:4](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/mina_base/state_body_hash.ml#L19)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBaseStateBodyHashStableV1(pub crate::bigint::BigInt);
 
 /// **OCaml name**: `Mina_base__Token_permissions.Stable.V1`
@@ -1296,7 +1297,7 @@ pub enum MinaBaseZkappPreconditionAccountStableV2StateA {
 /// Gid: `734`
 /// Location: [src/lib/mina_base/zkapp_state.ml:17:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/mina_base/zkapp_state.ml#L17)
 /// Args: crate :: bigint :: BigInt
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBaseZkappStateValueStableV1(pub PaddedSeq<crate::bigint::BigInt, 8>);
 
 /// **OCaml name**: `Mina_base__Zkapp_account.Stable.V2`
@@ -1349,7 +1350,7 @@ pub struct MinaBaseEpochLedgerValueStableV1 {
 ///
 /// Gid: `751`
 /// Location: [src/lib/mina_base/epoch_seed.ml:18:4](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/mina_base/epoch_seed.ml#L18)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBaseEpochSeedStableV1(pub crate::bigint::BigInt);
 
 /// Derived name: `Mina_base__Zkapp_precondition.Protocol_state.Stable.V1#time#a`
@@ -1602,7 +1603,7 @@ pub struct MinaBaseAccountUpdatePreconditionsStableV1 {
 /// Gid: `50`
 /// Location: [src/list0.ml:6:0](https://github.com/Minaprotocol/mina/blob/32a9161/src/list0.ml#L6)
 /// Args: Vec < crate :: bigint :: BigInt >
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBaseAccountUpdateBodyEventsStableV1(pub Vec<Vec<crate::bigint::BigInt>>);
 
 /// **OCaml name**: `Mina_base__Account_update.Body.Wire.Stable.V1`
@@ -1837,21 +1838,21 @@ pub struct MinaBaseCoinbaseStableV1 {
 ///
 /// Gid: `113`
 /// Location: [src/int.ml:19:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/int.ml#L19)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBasePendingCoinbaseStackIdStableV1(pub crate::number::Int32);
 
 /// **OCaml name**: `Mina_base__Pending_coinbase.Make_str.Coinbase_stack.Stable.V1`
 ///
 /// Gid: `818`
 /// Location: [src/lib/mina_base/pending_coinbase.ml:163:8](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/mina_base/pending_coinbase.ml#L163)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBasePendingCoinbaseCoinbaseStackStableV1(pub crate::bigint::BigInt);
 
 /// **OCaml name**: `Mina_base__Pending_coinbase.Make_str.Stack_hash.Stable.V1`
 ///
 /// Gid: `823`
 /// Location: [src/lib/mina_base/pending_coinbase.ml:223:8](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/mina_base/pending_coinbase.ml#L223)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBasePendingCoinbaseStackHashStableV1(pub crate::bigint::BigInt);
 
 /// **OCaml name**: `Mina_base__Pending_coinbase.Make_str.State_stack.Stable.V1`
@@ -1873,7 +1874,7 @@ pub struct MinaBasePendingCoinbaseStateStackStableV1 {
 ///
 /// Gid: `830`
 /// Location: [src/lib/mina_base/pending_coinbase.ml:370:8](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/mina_base/pending_coinbase.ml#L370)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBasePendingCoinbaseHashBuilderStableV1(pub crate::bigint::BigInt);
 
 /// **OCaml name**: `Mina_base__Pending_coinbase.Make_str.Stack_versioned.Stable.V1`
@@ -1895,7 +1896,7 @@ pub struct MinaBasePendingCoinbaseStackVersionedStableV1 {
 ///
 /// Gid: `838`
 /// Location: [src/lib/mina_base/pending_coinbase.ml:532:8](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/mina_base/pending_coinbase.ml#L532)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBasePendingCoinbaseHashVersionedStableV1(
     pub MinaBasePendingCoinbaseHashBuilderStableV1,
 );
@@ -1928,7 +1929,7 @@ pub struct MinaBasePendingCoinbaseMerkleTreeVersionedStableV2 {
 ///
 /// Gid: `83`
 /// Location: [src/string.ml:44:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/string.ml#L44)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBaseStagedLedgerHashAuxHashStableV1(pub crate::string::ByteString);
 
 /// **OCaml name**: `Mina_base__Staged_ledger_hash.Make_str.Pending_coinbase_aux.Stable.V1`
@@ -1943,7 +1944,7 @@ pub struct MinaBaseStagedLedgerHashAuxHashStableV1(pub crate::string::ByteString
 ///
 /// Gid: `83`
 /// Location: [src/string.ml:44:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/string.ml#L44)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBaseStagedLedgerHashPendingCoinbaseAuxStableV1(pub crate::string::ByteString);
 
 /// **OCaml name**: `Mina_base__Staged_ledger_hash.Make_str.Non_snark.Stable.V1`
@@ -1976,7 +1977,7 @@ pub struct MinaBaseStagedLedgerHashStableV1 {
 ///
 /// Gid: `848`
 /// Location: [src/lib/mina_base/stack_frame.ml:64:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/mina_base/stack_frame.ml#L64)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBaseStackFrameStableV1(pub crate::bigint::BigInt);
 
 /// **OCaml name**: `Mina_base__Sok_message.Make_str.Stable.V1`
@@ -2011,14 +2012,14 @@ pub struct MinaBaseProtocolConstantsCheckedValueStableV1 {
 ///
 /// Gid: `852`
 /// Location: [src/lib/mina_base/proof.ml:12:4](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/mina_base/proof.ml#L12)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBaseProofStableV2(pub PicklesProofProofsVerified2ReprStableV2);
 
 /// **OCaml name**: `Mina_base__Call_stack_digest.Make_str.Stable.V1`
 ///
 /// Gid: `854`
 /// Location: [src/lib/mina_base/call_stack_digest.ml:12:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/mina_base/call_stack_digest.ml#L12)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct MinaBaseCallStackDigestStableV1(pub crate::bigint::BigInt);
 
 /// **OCaml name**: `Mina_base__Fee_with_prover.Stable.V1`
@@ -2176,7 +2177,7 @@ pub struct MerkleAddressBinableArgStableV1(pub crate::number::Int32, pub crate::
 ///
 /// Gid: `83`
 /// Location: [src/string.ml:44:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/string.ml#L44)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct NetworkPeerPeerIdStableV1(pub crate::string::ByteString);
 
 /// **OCaml name**: `Trust_system__Banned_status.Stable.V1`
@@ -2201,14 +2202,14 @@ pub enum TrustSystemBannedStatusStableV1 {
 ///
 /// Gid: `83`
 /// Location: [src/string.ml:44:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/string.ml#L44)
-#[derive(Clone, Debug, PartialEq, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, BinProtRead, BinProtWrite)]
 pub struct ConsensusVrfOutputTruncatedStableV1(pub crate::string::ByteString);
 
 /// **OCaml name**: `Consensus__Body_reference.Stable.V1`
 ///
 /// Gid: `922`
 /// Location: [src/lib/consensus/body_reference.ml:17:4](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/consensus/body_reference.ml#L17)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct ConsensusBodyReferenceStableV1(pub Blake2MakeStableV1);
 
 /// **OCaml name**: `Consensus__Global_slot.Make_str.Stable.V1`
@@ -2371,7 +2372,7 @@ pub struct TransactionSnarkStatementWithSokStableV2 {
 ///
 /// Gid: `992`
 /// Location: [src/lib/transaction_snark/transaction_snark.ml:413:8](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/transaction_snark/transaction_snark.ml#L413)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct TransactionSnarkProofStableV2(pub PicklesProofProofsVerified2ReprStableV2);
 
 /// **OCaml name**: `Transaction_snark.Make_str.Stable.V2`
@@ -2388,7 +2389,7 @@ pub struct TransactionSnarkStableV2 {
 ///
 /// Gid: `996`
 /// Location: [src/lib/ledger_proof/ledger_proof.ml:10:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/ledger_proof/ledger_proof.ml#L10)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct LedgerProofProdStableV2(pub TransactionSnarkStableV2);
 
 /// **OCaml name**: `Transaction_snark_work.Statement.Stable.V2`
@@ -2455,7 +2456,7 @@ pub enum StagedLedgerDiffDiffPreDiffWithAtMostOneCoinbaseStableV2Coinbase {
 ///
 /// Gid: `1005`
 /// Location: [src/lib/staged_ledger_diff/diff.ml:88:8](https://github.com/Minaprotocol/mina/blob/32a9161/src/lib/staged_ledger_diff/diff.ml#L88)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct StagedLedgerDiffDiffFtStableV1(pub MinaBaseCoinbaseFeeTransferStableV1);
 
 /// **OCaml name**: `Staged_ledger_diff__Diff.Make_str.Pre_diff_with_at_most_two_coinbase.Stable.V2`
@@ -2532,7 +2533,7 @@ pub struct StagedLedgerDiffBodyStableV1 {
 ///
 /// Gid: `113`
 /// Location: [src/int.ml:19:6](https://github.com/Minaprotocol/mina/blob/32a9161/src/int.ml#L19)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(Clone, Debug, Deref, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct ParallelScanSequenceNumberStableV1(pub crate::number::Int32);
 
 /// **OCaml name**: `Parallel_scan.Job_status.Stable.V1`

--- a/src/v2/generated.rs
+++ b/src/v2/generated.rs
@@ -1,6 +1,6 @@
 use binprot_derive::{BinProtRead, BinProtWrite};
-use serde::{Deserialize, Serialize};
 use derive_more::Deref;
+use serde::{Deserialize, Serialize};
 
 use crate::pseq::PaddedSeq;
 

--- a/src/v2/hashing.rs
+++ b/src/v2/hashing.rs
@@ -1,0 +1,21 @@
+use super::generated;
+use sha2::{
+    digest::{generic_array::GenericArray, typenum::U32},
+    Digest, Sha256,
+};
+
+impl generated::MinaBaseStagedLedgerHashNonSnarkStableV1 {
+    pub fn sha256(&self) -> GenericArray<u8, U32> {
+        let mut ledger_hash_bytes: [u8; 32] = [0; 32];
+
+        ledger_hash_bytes.copy_from_slice(self.ledger_hash.as_ref());
+        ledger_hash_bytes.reverse();
+
+        let mut hasher = Sha256::new();
+        hasher.update(ledger_hash_bytes);
+        hasher.update(self.aux_hash.as_ref());
+        hasher.update(self.pending_coinbase_aux.as_ref());
+
+        hasher.finalize()
+    }
+}

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -1,5 +1,7 @@
 mod generated;
+mod hashing;
 mod manual;
 
 pub use generated::*;
+pub use hashing::*;
 pub use manual::*;

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -1,7 +1,9 @@
 mod generated;
+#[cfg(feature = "hashing")]
 mod hashing;
 mod manual;
 
 pub use generated::*;
+#[cfg(feature = "hashing")]
 pub use hashing::*;
 pub use manual::*;

--- a/src/v2/state_hash.rs
+++ b/src/v2/state_hash.rs
@@ -1,0 +1,17 @@
+use std::fmt;
+
+use super::StateHash;
+
+pub type StateHashStable = StateHash;
+
+impl fmt::Display for StateHashStable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut buf = vec![0x01];
+        binprot::BinProtWrite::binprot_write(self, &mut buf).or(Err(fmt::Error))?;
+
+        bs58::encode(&buf)
+            .with_check_version(0x10)
+            .into_string()
+            .fmt(f)
+    }
+}


### PR DESCRIPTION
This adds `Deref` implementation to tuples with a single element.
This is to avoid having to use multiples `.0` to reach the inner element, that's a bit confusing to read and write.

See this commit for example: https://github.com/name-placeholder/mina-block-verifier-poc/commit/fe5f0f54741ff68d52dcf97ac77303d2496af235

@akoptelov I have manually added `derive_more::Deref` to the generated types (in `src/v2/generated.rs`).
Next time those types are automatically generated, would it be possible to add `Deref` too ?
I'm not sure where they are generated, could you point me to where I could add `Deref` automatically ?